### PR TITLE
Fix Dart SDK version in pubspec.yaml for workflow compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.1+2
 publish_to: 'none'
 
 environment:
-  sdk: ">=3.8.0 <4.0.0"
+  sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -24,7 +24,7 @@ dependencies:
   flutter_secure_storage: ^9.2.2
   shared_preferences: ^2.3.2
   
-  # UI Components - Enhanced Markdown  
+  # UI Components - Enhanced Markdown 
   gpt_markdown: ^1.1.2
   cached_network_image: ^3.3.1
   
@@ -69,8 +69,8 @@ flutter:
   uses-material-design: true
   
   assets:
-    - assets/icons/
-    - assets/openapi.json
+     - assets/icons/
+     - assets/openapi.json
 
 flutter_native_splash:
   # Background color (Conduit dark theme)
@@ -85,4 +85,4 @@ flutter_native_splash:
   
   # Web specific settings
   web: false
-    
+   


### PR DESCRIPTION
This PR fixes the invalid Dart SDK requirement in pubspec.yaml (changed to >=3.5.0 <4.0.0 to match current Flutter/Dart versions). This should resolve the dependency resolution error in the workflow. Merge this, then re-run the Flutter iOS Build workflow.