### PR TITLE
Downgrade flutter_lints to be compatible with Dart 3.5.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,7 +57,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^6.0.0
+  flutter_lints: ^3.0.0
   build_runner: ^2.4.11
   freezed: ^3.0.0
   json_serializable: ^6.8.0


### PR DESCRIPTION
This PR fixes the second dependency resolution error by downgrading flutter_lints from ^6.0.0 to ^3.0.0.

The error occurred because:
- flutter_lints 6.0.0 requires Dart SDK ^3.8.0
- But our GitHub Actions runner is using Dart 3.5.3
- By using flutter_lints ^3.0.0, we maintain compatibility with Dart 3.5.3

After merging this PR, the Flutter iOS build workflow should be able to progress further.